### PR TITLE
Fix CONTRIBUTING.md bad link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,4 +33,4 @@ While sending a PR, always remember not to send one from your master branch; it'
 It is highly recommended to follow the below guidelines while writing commits and sending PRs:
 
 - https://blog.github.com/2015-01-21-how-to-write-the-perfect-pull-request/
-- https://code.likeagirl.io/useful-tips-for-writing-better-git-commit-messages-808770609503
+- https://www.conventionalcommits.org/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # CopyUrlToMD
 
+[![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
+
 Built from [kryptokinght/react-extension-boilerplate](https://github.com/kryptokinght/react-extension-boilerplate)
 
 CopyUrlToMD is a utility browser extension to help you copy the URL of certain tabs into your system clipboard with Markdown-formatted.


### PR DESCRIPTION
## issue #8 
https://github.com/sss63232/CopyUrlToMD/blame/master/CONTRIBUTING.md#L36
get bad link (410)

Follow the discussion, change the commit guide to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) and add the badge to README.md.
